### PR TITLE
Fix stale owner lock cleanup on unix

### DIFF
--- a/src/core/owner.rs
+++ b/src/core/owner.rs
@@ -40,6 +40,11 @@ impl Drop for ServiceOwnerGuard {
 
         let _ = std::fs::remove_file(self.paths.pid_file_path());
 
+        #[cfg(unix)]
+        {
+            let _ = std::fs::remove_file(self.paths.owner_lock_path());
+        }
+
         #[cfg(windows)]
         {
             let _ = std::fs::remove_file(self.paths.owner_lock_path());
@@ -242,6 +247,7 @@ fn cleanup_runtime_artifacts(paths: &ServicePaths) {
 
     #[cfg(unix)]
     {
+        let _ = std::fs::remove_file(paths.owner_lock_path());
         let _ = std::fs::remove_file(paths.ipc_path());
     }
 


### PR DESCRIPTION
Clean up the unix owner lock file together with pid/ipc artifacts when releasing or recovering service ownership.

This prevents stale root-owned lock files under /tmp/verge from blocking the next startup after a reboot/switch-back scenario.