### PR TITLE
fix(service): recover from corrupted state files instead of failing

### DIFF
--- a/src/core/desired.rs
+++ b/src/core/desired.rs
@@ -98,9 +98,17 @@ pub async fn load_active_owner() -> Result<Option<ActiveOwnerState>> {
     let path = service_paths().active_owner_path();
     secure_state_file_if_exists(&path)?;
     match tokio::fs::read(&path).await {
-        Ok(content) => serde_json::from_slice(&content)
-            .map(Some)
-            .with_context(|| format!("failed to parse active owner {path:?}")),
+        Ok(content) => match serde_json::from_slice(&content) {
+            Ok(state) => Ok(Some(state)),
+            Err(error) => {
+                warn!(
+                    "Active owner state {path:?} is corrupted ({error}); \
+                     backing it up and starting with no active owner"
+                );
+                backup_corrupt_state_file(&path).await?;
+                Ok(None)
+            }
+        },
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error).with_context(|| format!("failed to read active owner {path:?}")),
     }
@@ -280,11 +288,40 @@ where
 {
     secure_state_file_if_exists(path)?;
     match tokio::fs::read(path).await {
-        Ok(content) => serde_json::from_slice(&content)
-            .with_context(|| format!("failed to parse state {path:?}")),
+        Ok(content) => match serde_json::from_slice(&content) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                warn!(
+                    "State file {path:?} is corrupted ({error}); \
+                     backing it up and resetting to defaults"
+                );
+                backup_corrupt_state_file(path).await?;
+                Ok(T::default())
+            }
+        },
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
         Err(error) => Err(error).with_context(|| format!("failed to read state {path:?}")),
     }
+}
+
+/// 状态文件损坏（例如写入被中断留下的全零文件）时备份为 *.corrupt.bak，
+/// 让后续流程可以从默认状态恢复，而不是每次都在解析处失败。
+async fn backup_corrupt_state_file(path: &std::path::Path) -> Result<std::path::PathBuf> {
+    let backup = path.with_extension("json.corrupt.bak");
+    match tokio::fs::remove_file(&backup).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to replace previous corrupt state backup {backup:?}")
+            });
+        }
+    }
+    tokio::fs::rename(path, &backup)
+        .await
+        .with_context(|| format!("failed to back up corrupted state {path:?} to {backup:?}"))?;
+    info!("Backed up corrupted state file {path:?} -> {backup:?}");
+    Ok(backup)
 }
 
 async fn write_json_atomic<T>(path: &std::path::Path, value: &T) -> Result<()>
@@ -475,6 +512,53 @@ mod owner_tests {
             br#"{"core_should_be_running":true}"#
         );
         std::fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn corrupted_owner_desired_state_is_backed_up_and_reset() -> anyhow::Result<()> {
+        let owner = test_owner(90_008);
+        let config = ClashConfig {
+            core_config: CoreConfig {
+                core_path: "/tmp/mock-core-corrupt".to_string(),
+                ..Default::default()
+            },
+            log_config: Default::default(),
+        };
+        persist_owner_core_started(&owner, &config).await?;
+
+        // 模拟写盘被中断后留下的全零文件
+        let path = crate::service_paths()
+            .for_owner_key(&owner.key)
+            .desired_state_path();
+        std::fs::write(&path, vec![0u8; 64])?;
+
+        let state = load_owner_desired_state(&owner.key).await?;
+        assert!(!state.core_should_be_running);
+        assert!(!path.exists());
+
+        let backup = path.with_extension("json.corrupt.bak");
+        assert_eq!(std::fs::read(&backup)?, vec![0u8; 64]);
+        std::fs::remove_file(backup)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn corrupted_active_owner_is_backed_up_and_cleared() -> anyhow::Result<()> {
+        clear_active_owner().await?;
+        let owner = test_owner(90_009);
+        persist_active_owner(&owner).await?;
+
+        let path = crate::service_paths().active_owner_path();
+        std::fs::write(&path, b"not-valid-json{{{")?;
+
+        assert!(load_active_owner().await?.is_none());
+        assert!(!path.exists());
+
+        let backup = path.with_extension("json.corrupt.bak");
+        assert_eq!(std::fs::read(&backup)?, b"not-valid-json{{{");
+        std::fs::remove_file(backup)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## 问题

状态文件（`desired-state.json`、`active-owner.json`、`owner-generation.json`）在写入被中断时可能损坏（断电、强杀进程等，典型表现为全零文件，见 clash-verge-rev/clash-verge-rev#7521 中用户提供的样本）。

此前所有读取路径都会把 JSON 解析错误向上传播：服务启动失败、IPC 端点永远不会就绪，GUI 只报一句 `IPC path not ready`，日志里没有任何相关信息。用户只能手动找到并删除 `C:\ProgramData\clash-verge-service\desired-state.json` 才能恢复（clash-verge-rev/clash-verge-rev#7074 中的 workaround）。

虽然 main 分支已让 `restore_desired_state` 容忍恢复失败并保持 IPC 可用，但 `read_json_or_default` / `load_active_owner` 在 IPC 命令路径上仍会传播解析错误，异常状态下服务依然无法正常工作。

## 修改

- `read_json_or_default`：解析失败时输出 warn 日志，将损坏文件备份为 `*.json.corrupt.bak`，然后返回默认值；
- `load_active_owner`：同样容错，损坏时按"无 active owner"处理；
- 新增 `backup_corrupt_state_file`：备份前清理同名旧备份，避免 Windows 上 rename 因目标已存在而失败；
- NotFound 之外的 I/O 错误仍然向上传播，不掩盖真实的文件系统问题。

## 测试

新增两个单元测试：

- `corrupted_owner_desired_state_is_backed_up_and_reset`：写入全零文件（复刻 #7521 样本），验证返回默认值且原文件被备份；
- `corrupted_active_owner_is_backed_up_and_cleared`：写入非法 JSON，验证按无 active owner 恢复且完成备份。

本地已通过（与 CI 相同命令）：

- `cargo test --all-features --lib`（72 passed）
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --check`

Ref clash-verge-rev/clash-verge-rev#7521