### PR TITLE
chore(deps): migrate kode-bridge to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "clash_verge_service_ipc"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "clash_verge_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,12 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,21 +557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "iptools"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,14 +588,14 @@ dependencies = [
 
 [[package]]
 name = "kode-bridge"
-version = "0.4.2"
-source = "git+https://github.com/clash-verge-rev/kode-bridge.git?branch=dev#9dc3ee4689e46252600b9c1b12d20961fce113b4"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011bbb08cc7dfa49d284a5a96917c89efaab0a0fec0a42dca2db3d24fa126a27"
 dependencies = [
  "bytes",
  "futures",
  "http",
  "httparse",
- "interprocess",
  "libc",
  "parking_lot",
  "path-tree",
@@ -631,7 +610,6 @@ dependencies = [
  "toml",
  "tracing",
  "url",
- "widestring",
  "windows-sys 0.61.2",
 ]
 
@@ -889,12 +867,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -1319,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1329,14 +1301,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1347,7 +1319,7 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -1717,12 +1689,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ default = []
 
 
 [dependencies]
-kode-bridge = { git = "https://github.com/clash-verge-rev/kode-bridge.git", branch = "dev", version = "0.4.2", features = ["server"], optional = true }
+kode-bridge = { version = "0.5.1", features = ["server"], optional = true }
 once_cell = { version = "1.21", features = ["parking_lot"], optional = true }
 anyhow = { version = "1.0", optional = true }
 http = { version = "1.3", optional = true }
@@ -134,7 +134,7 @@ windows-sys = { version = "0.61.2", optional = true, features = [
 ] }
 
 [dev-dependencies]
-kode-bridge = { git = "https://github.com/clash-verge-rev/kode-bridge.git", branch = "dev", version = "0.4.2", default-features = false, features = [
+kode-bridge = { version = "0.5.1", default-features = false, features = [
     "server",
     "client",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clash_verge_service_ipc"
-version = "2.6.3"
+version = "2.6.4"
 edition = "2024"
 authors = ["Tunglies"]
 license = "GPL-3.0"


### PR DESCRIPTION
## Summary
- migrate kode-bridge from its git dev branch to the official crates.io 0.5.1 release
- bump clash_verge_service_ipc from 2.6.3 to 2.6.4
- retain the existing IPC identity protections: kernel peer credentials, Windows SCM/PID/LocalSystem verification, Windows system-service health client requirement, and Unix 0o666 listener mode

## Verification
- cargo fmt --all --check
- cargo clippy --features "standalone client" --lib --bins -- -D warnings
- cargo clippy --all-features --all-targets -- -D warnings
- cargo test --all-features
- cargo tree --all-features -i kode-bridge
- git diff --check

The lockfile resolves kode-bridge 0.5.1 from crates.io with checksum `011bbb08cc7dfa49d284a5a96917c89efaab0a0fec0a42dca2db3d24fa126a27`.